### PR TITLE
Adds support for sampling independence

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,8 +1,38 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.11.6"
+julia_version = "1.11.7"
 manifest_format = "2.0"
-project_hash = "361758f89e54171b3c844cdc4b03cb6bcaaf2a05"
+project_hash = "6d760063459454be55cbce1690a993e9995c8577"
+
+[[deps.Accessors]]
+deps = ["CompositionsBase", "ConstructionBase", "Dates", "InverseFunctions", "MacroTools"]
+git-tree-sha1 = "3b86719127f50670efe356bc11073d84b4ed7a5d"
+uuid = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
+version = "0.1.42"
+
+    [deps.Accessors.extensions]
+    AxisKeysExt = "AxisKeys"
+    IntervalSetsExt = "IntervalSets"
+    LinearAlgebraExt = "LinearAlgebra"
+    StaticArraysExt = "StaticArrays"
+    StructArraysExt = "StructArrays"
+    TestExt = "Test"
+    UnitfulExt = "Unitful"
+
+    [deps.Accessors.weakdeps]
+    AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
+    IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
+    LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+    StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+    Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[[deps.AliasTables]]
+deps = ["PtrArrays", "Random"]
+git-tree-sha1 = "9876e1e164b144ca45e9e3198d0b689cadfed9ff"
+uuid = "66dad0bd-aa9a-41b7-9441-69ab47430ed8"
+version = "1.1.3"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -26,6 +56,35 @@ weakdeps = ["Dates", "LinearAlgebra"]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 version = "1.1.1+0"
+
+[[deps.CompositionsBase]]
+git-tree-sha1 = "802bb88cd69dfd1509f6670416bd4434015693ad"
+uuid = "a33af91c-f02d-484b-be07-31d278c5ca2b"
+version = "0.1.2"
+weakdeps = ["InverseFunctions"]
+
+    [deps.CompositionsBase.extensions]
+    CompositionsBaseInverseFunctionsExt = "InverseFunctions"
+
+[[deps.ConcreteStructs]]
+git-tree-sha1 = "f749037478283d372048690eb3b5f92a79432b34"
+uuid = "2569d6c7-a4a2-43d3-a901-331e8e4be471"
+version = "0.2.3"
+
+[[deps.ConstructionBase]]
+git-tree-sha1 = "b4b092499347b18a015186eae3042f72267106cb"
+uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+version = "1.6.0"
+
+    [deps.ConstructionBase.extensions]
+    ConstructionBaseIntervalSetsExt = "IntervalSets"
+    ConstructionBaseLinearAlgebraExt = "LinearAlgebra"
+    ConstructionBaseStaticArraysExt = "StaticArrays"
+
+    [deps.ConstructionBase.weakdeps]
+    IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
+    LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [[deps.Crayons]]
 git-tree-sha1 = "249fe38abf76d48563e2f4556bebd215aa317e15"
@@ -59,15 +118,60 @@ deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 version = "1.11.0"
 
+[[deps.DelimitedFiles]]
+deps = ["Mmap"]
+git-tree-sha1 = "9e2f36d3c96a820c678f2f1f1782582fcf685bae"
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+version = "1.9.1"
+
 [[deps.Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 version = "1.11.0"
 
+[[deps.Distributions]]
+deps = ["AliasTables", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "SpecialFunctions", "Statistics", "StatsAPI", "StatsBase", "StatsFuns"]
+git-tree-sha1 = "3e6d038b77f22791b8e3472b7c633acea1ecac06"
+uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
+version = "0.25.120"
+
+    [deps.Distributions.extensions]
+    DistributionsChainRulesCoreExt = "ChainRulesCore"
+    DistributionsDensityInterfaceExt = "DensityInterface"
+    DistributionsTestExt = "Test"
+
+    [deps.Distributions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    DensityInterface = "b429d917-457f-4dbc-8f4c-0cc954292b1d"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[deps.DocStringExtensions]]
+git-tree-sha1 = "7442a5dfe1ebb773c29cc2962a8980f47221d76c"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.9.5"
+
+[[deps.FillArrays]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "173e4d8f14230a7523ae11b9a3fa9edb3e0efd78"
+uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
+version = "1.14.0"
+weakdeps = ["PDMats", "SparseArrays", "Statistics"]
+
+    [deps.FillArrays.extensions]
+    FillArraysPDMatsExt = "PDMats"
+    FillArraysSparseArraysExt = "SparseArrays"
+    FillArraysStatisticsExt = "Statistics"
+
 [[deps.Future]]
 deps = ["Random"]
 uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 version = "1.11.0"
+
+[[deps.HypergeometricFunctions]]
+deps = ["LinearAlgebra", "OpenLibm_jll", "SpecialFunctions"]
+git-tree-sha1 = "68c173f4f449de5b438ee67ed0c9c748dc31a2ec"
+uuid = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
+version = "0.3.28"
 
 [[deps.InlineStrings]]
 git-tree-sha1 = "8594fac023c5ce1ef78260f24d1ad18b4327b420"
@@ -82,25 +186,60 @@ version = "1.4.4"
     ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
     Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 
+[[deps.IntegerMathUtils]]
+git-tree-sha1 = "4c1acff2dc6b6967e7e750633c50bc3b8d83e617"
+uuid = "18e54dd8-cb9d-406c-a71d-865a43cbb235"
+version = "0.1.3"
+
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 version = "1.11.0"
+
+[[deps.InverseFunctions]]
+git-tree-sha1 = "a779299d77cd080bf77b97535acecd73e1c5e5cb"
+uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
+version = "0.1.17"
+
+    [deps.InverseFunctions.extensions]
+    InverseFunctionsDatesExt = "Dates"
+    InverseFunctionsTestExt = "Test"
+
+    [deps.InverseFunctions.weakdeps]
+    Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[deps.InvertedIndices]]
 git-tree-sha1 = "6da3c4316095de0f5ee2ebd875df8721e7e0bdbe"
 uuid = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"
 version = "1.3.1"
 
+[[deps.IrrationalConstants]]
+git-tree-sha1 = "e2222959fbc6c19554dc15174c81bf7bf3aa691c"
+uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
+version = "0.2.4"
+
 [[deps.IteratorInterfaceExtensions]]
 git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
 uuid = "82899510-4779-5014-852e-03e436cf321d"
 version = "1.0.0"
 
+[[deps.JLLWrappers]]
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "0533e564aae234aff59ab625543145446d8b6ec2"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.7.1"
+
 [[deps.LaTeXStrings]]
 git-tree-sha1 = "dda21b8cbd6a6c40d9d02a73230f9d70fed6918c"
 uuid = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 version = "1.4.0"
+
+[[deps.LatticeRules]]
+deps = ["Random"]
+git-tree-sha1 = "7f5b02258a3ca0221a6a9710b0a0a2e8fb4957fe"
+uuid = "73f95e8e-ec14-4e6a-8b18-0d2e271c4e55"
+version = "0.0.1"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -110,6 +249,27 @@ version = "1.11.0"
 deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 version = "1.11.0"
+
+[[deps.LogExpFunctions]]
+deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "13ca9e2586b89836fd20cccf56e57e2b9ae7f38f"
+uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+version = "0.3.29"
+
+    [deps.LogExpFunctions.extensions]
+    LogExpFunctionsChainRulesCoreExt = "ChainRulesCore"
+    LogExpFunctionsChangesOfVariablesExt = "ChangesOfVariables"
+    LogExpFunctionsInverseFunctionsExt = "InverseFunctions"
+
+    [deps.LogExpFunctions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    ChangesOfVariables = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
+    InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
+
+[[deps.MacroTools]]
+git-tree-sha1 = "1e0228a030642014fe5cfe68c2c0a818f9e3f522"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.16"
 
 [[deps.Markdown]]
 deps = ["Base64"]
@@ -122,15 +282,36 @@ git-tree-sha1 = "ec4f7fbeab05d7747bdf98eb74d130a2a2ed298d"
 uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
 version = "1.2.0"
 
+[[deps.Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+version = "1.11.0"
+
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
 version = "0.3.27+1"
 
+[[deps.OpenLibm_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
+version = "0.8.5+0"
+
+[[deps.OpenSpecFun_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "1346c9208249809840c91b26703912dff463d335"
+uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
+version = "0.5.6+0"
+
 [[deps.OrderedCollections]]
 git-tree-sha1 = "05868e21324cede2207c6f0f466b4bfef6d5e7ee"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.8.1"
+
+[[deps.PDMats]]
+deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
+git-tree-sha1 = "f07c06228a1c670ae4c87d1276b92c7c597fdda0"
+uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
+version = "0.11.35"
 
 [[deps.PooledArrays]]
 deps = ["DataAPI", "Future"]
@@ -156,6 +337,12 @@ git-tree-sha1 = "1101cd475833706e4d0e7b122218257178f48f34"
 uuid = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 version = "2.4.0"
 
+[[deps.Primes]]
+deps = ["IntegerMathUtils"]
+git-tree-sha1 = "25cdd1d20cd005b52fc12cb6be3f75faaf59bb9b"
+uuid = "27ebfcd6-29c5-5fa9-bf4b-fb8fc14df3ae"
+version = "0.5.7"
+
 [[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
@@ -167,6 +354,33 @@ git-tree-sha1 = "13c5103482a8ed1536a54c08d0e742ae3dca2d42"
 uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
 version = "1.10.4"
 
+[[deps.PtrArrays]]
+git-tree-sha1 = "1d36ef11a9aaf1e8b74dacc6a731dd1de8fd493d"
+uuid = "43287f4e-b6f4-7ad1-bb20-aadabca52c3d"
+version = "1.3.0"
+
+[[deps.QuadGK]]
+deps = ["DataStructures", "LinearAlgebra"]
+git-tree-sha1 = "9da16da70037ba9d701192e27befedefb91ec284"
+uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
+version = "2.11.2"
+
+    [deps.QuadGK.extensions]
+    QuadGKEnzymeExt = "Enzyme"
+
+    [deps.QuadGK.weakdeps]
+    Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+
+[[deps.QuasiMonteCarlo]]
+deps = ["Accessors", "ConcreteStructs", "LatticeRules", "LinearAlgebra", "Primes", "Random", "Requires", "Sobol", "StatsBase"]
+git-tree-sha1 = "cc086f8485bce77b6187141e1413c3b55f9a4341"
+uuid = "8a4e6c94-4038-4cdc-81c3-7e6ffdb2a71b"
+version = "0.3.3"
+weakdeps = ["Distributions"]
+
+    [deps.QuasiMonteCarlo.extensions]
+    QuasiMonteCarloDistributionsExt = "Distributions"
+
 [[deps.Random]]
 deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -176,6 +390,24 @@ version = "1.11.0"
 git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
 uuid = "189a3867-3050-52da-a836-e630ba90ab69"
 version = "1.2.2"
+
+[[deps.Requires]]
+deps = ["UUIDs"]
+git-tree-sha1 = "62389eeff14780bfe55195b7204c0d8738436d64"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "1.3.1"
+
+[[deps.Rmath]]
+deps = ["Random", "Rmath_jll"]
+git-tree-sha1 = "852bd0f55565a9e973fcfee83a84413270224dc4"
+uuid = "79098fc4-a85e-5d69-aa6a-4863f24498fa"
+version = "0.8.0"
+
+[[deps.Rmath_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "58cdd8fb2201a6267e1db87ff148dd6c1dbd8ad8"
+uuid = "f50d1b31-88e8-58de-be2c-1cc44531875f"
+version = "0.5.1+0"
 
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -191,6 +423,12 @@ version = "1.4.8"
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 version = "1.11.0"
 
+[[deps.Sobol]]
+deps = ["DelimitedFiles", "Random"]
+git-tree-sha1 = "5a74ac22a9daef23705f010f72c81d6925b19df8"
+uuid = "ed01d8cd-4d21-5b2a-85b4-cc3bdc58bad4"
+version = "1.5.0"
+
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 version = "1.11.0"
@@ -201,23 +439,73 @@ git-tree-sha1 = "64d974c2e6fdf07f8155b5b2ca2ffa9069b608d9"
 uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
 version = "1.2.2"
 
+[[deps.SparseArrays]]
+deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+version = "1.11.0"
+
+[[deps.SpecialFunctions]]
+deps = ["IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
+git-tree-sha1 = "41852b8679f78c8d8961eeadc8f62cef861a52e3"
+uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
+version = "2.5.1"
+
+    [deps.SpecialFunctions.extensions]
+    SpecialFunctionsChainRulesCoreExt = "ChainRulesCore"
+
+    [deps.SpecialFunctions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+
 [[deps.Statistics]]
 deps = ["LinearAlgebra"]
 git-tree-sha1 = "ae3bb1eb3bba077cd276bc5cfc337cc65c3075c0"
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 version = "1.11.1"
+weakdeps = ["SparseArrays"]
 
     [deps.Statistics.extensions]
     SparseArraysExt = ["SparseArrays"]
 
-    [deps.Statistics.weakdeps]
-    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+[[deps.StatsAPI]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "9d72a13a3f4dd3795a195ac5a44d7d6ff5f552ff"
+uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
+version = "1.7.1"
+
+[[deps.StatsBase]]
+deps = ["AliasTables", "DataAPI", "DataStructures", "LinearAlgebra", "LogExpFunctions", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
+git-tree-sha1 = "2c962245732371acd51700dbb268af311bddd719"
+uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+version = "0.34.6"
+
+[[deps.StatsFuns]]
+deps = ["HypergeometricFunctions", "IrrationalConstants", "LogExpFunctions", "Reexport", "Rmath", "SpecialFunctions"]
+git-tree-sha1 = "8e45cecc66f3b42633b8ce14d431e8e57a3e242e"
+uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
+version = "1.5.0"
+
+    [deps.StatsFuns.extensions]
+    StatsFunsChainRulesCoreExt = "ChainRulesCore"
+    StatsFunsInverseFunctionsExt = "InverseFunctions"
+
+    [deps.StatsFuns.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 
 [[deps.StringManipulation]]
 deps = ["PrecompileTools"]
 git-tree-sha1 = "725421ae8e530ec29bcbdddbe91ff8053421d023"
 uuid = "892a3eda-7b42-436c-8928-eab12a02cf0e"
 version = "0.4.1"
+
+[[deps.SuiteSparse]]
+deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
+uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
+
+[[deps.SuiteSparse_jll]]
+deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]
+uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
+version = "7.7.0+0"
 
 [[deps.TOML]]
 deps = ["Dates"]

--- a/Project.toml
+++ b/Project.toml
@@ -6,12 +6,20 @@ version = "0.2.1"
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
+QuasiMonteCarlo = "8a4e6c94-4038-4cdc-81c3-7e6ffdb2a71b"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
-julia = "1.11"
 DataFrames = "1.7"
+Distributions = "0.25.120"
+DocStringExtensions = "0.9.5"
 ProgressMeter = "1.10"
+QuasiMonteCarlo = "0.3.3"
+Random = "1.11.0"
+julia = "1.11"
 
 [extras]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/SAShE.jl
+++ b/src/SAShE.jl
@@ -3,10 +3,12 @@ module SAShE
 using Base.Iterators: repeated
 using DataFrames, Distributed, ProgressMeter
 
+using DocStringExtensions
 
 include("shapley_effect.jl")
+include("samples.jl")
 
-export problem
+export problem, SAShESample
 export solve
 
 end

--- a/src/SAShE.jl
+++ b/src/SAShE.jl
@@ -5,10 +5,10 @@ using DataFrames, Distributed, ProgressMeter
 
 using DocStringExtensions
 
-include("shapley_effect.jl")
 include("samples.jl")
+include("shapley_effect.jl")
 
 export problem, SAShESample
-export solve
+export solve, analyze
 
 end

--- a/src/samples.jl
+++ b/src/samples.jl
@@ -1,0 +1,201 @@
+using DataFrames
+using Random
+using Distributions
+import QuasiMonteCarlo as QMC
+
+"""
+    _generate_samples(A::DataFrame, B::DataFrame)
+    _generate_samples(A::DataFrame, B::DataFrame, permutations::Matrix{Int64})
+    _generate_samples(A::DataFrame, B::DataFrame, sampler)
+
+Generate samples for use with SAShE.
+
+Supports sample generation with and without a pre-determined permutation matrix.
+
+# Arguments
+- `A`: First sample set to use
+- `B`: Second sample set to use
+- `permutations`: Permutations to use for cross-sampling between `A` and `B` (optional)
+- `sampler` : Method to generate permutations (optional)
+
+# Returns
+Tuple: Samples to be evaluated and applied permutation matrix.
+"""
+function _generate_samples(A::DataFrame, B::DataFrame, permutations::Matrix{Int64})
+    SAShE._validate_problem(A, B)
+    n_samples, n_factors = size(A)
+
+    # Initialize generated sample
+    Z = zeros(n_samples * (n_factors + 1), n_factors)
+
+    sample_count = 1
+    for i in 1:n_samples
+        # Leave one sample as is to create N(d+1) samples
+        # where N is the number of base samples, and d is the number of factors (dimensions)
+        Z[sample_count, :] .= collect(A[i, :])
+        sample_count += 1
+
+        _A = collect(A[i, :])
+        _B = collect(B[i, :])
+        πₙ = permutations[i, :]
+
+        for param_idx ∈ 1:n_factors
+            Zₙ = @view Z[sample_count, :]
+
+            # Target param index is different from param_idx.
+            # t_param_idx = πₙ[param_idx]
+            Zₙ[πₙ[1:(param_idx)]] .= @view _B[πₙ[1:(param_idx)]]
+            Zₙ[πₙ[(param_idx+1):end]] .= @view _A[πₙ[(param_idx+1):end]]
+            sample_count += 1
+        end
+    end
+
+    return DataFrame(Z, names(A)), permutations
+end
+function _generate_samples(A::DataFrame, B::DataFrame)
+    n_samples, n_factors = size(A)
+    _permutations = collect(hcat(sortperm.(eachrow(rand(n_samples, n_factors)))...)')
+
+    return _generate_samples(A, B, _permutations)
+end
+function _generate_samples(A::DataFrame, B::DataFrame, sampler)
+    n_samples, n_factors = size(A)
+    permutations = collect(
+        hcat(sortperm.(eachcol(QMC.sample(n_samples, n_factors, sampler())))...)'
+    )
+
+    return _generate_samples(A, B, permutations)
+end
+
+"""
+    _even_split(factor_names, X)
+
+Split a given sample set `X` into two equally sized DataFrames.
+"""
+function _even_split(factor_names, X)
+    n_factors = length(factor_names)
+    n_samples = size(X, 1)
+    half_size = Int64(n_samples / 2)
+    A = DataFrame(zeros(half_size, n_factors), factor_names)
+    B = copy(A)
+
+    A[:, :] = X[1:half_size, :]
+    B[:, :] = X[(half_size+1):end, :]
+
+    return A, B
+end
+
+"""
+    create_sample(factor_names::Vector, n_samples::Int64, factor_dist::Vector)
+    create_sample(factor_names::Vector, X::Matrix)
+
+Create samples for use with SAShE.
+
+Supports random sampling by creating new samples:
+1. Based on known distributions
+2. From an existing base sample `X` \
+   Sample `X` must be divisible by 2.
+
+The generated sample size will be `N(d+1)`, where `N` is the base sample size and `d` is the
+number of factors (i.e., the dimensionality of the problem).
+
+# Arguments
+- `factor_names`: Vector of factor names (typically String or Symbol)
+- `n_samples`: Number of base samples desired.
+- `factor_dist`: Distributions for each factor
+- `X`: Base sample to use
+
+# Returns
+Tuple: Samples to be evaluated and applied permutation matrix.
+"""
+function create_sample(factor_names::Vector, n_samples::Int64, factor_dist::Vector)
+    A, B = _even_split(factor_names, zeros(n_samples, n_factors))
+
+    for (i, fd) in enumerate(factor_dist)
+        A[:, i] .= rand(fd, n_samples)
+        B[:, i] .= rand(fd, n_samples)
+    end
+
+    return _generate_samples(A, B)
+end
+function create_sample(factor_names::Vector, X::Matrix)
+    A, B = _even_split(factor_names, X)
+
+    return _generate_samples(A, B)
+end
+
+"""
+    SAShESample(factor_names::Union{Vector{String},Vector{Symbol}}, n_samples::Int64, factor_dist::Vector)
+    SAShESample(factor_names::Union{Vector{String},Vector{Symbol}}, samples::Matrix)
+    SAShESample(factor_names::Union{Vector{String},Vector{Symbol}}, samples::Matrix, sampler)
+    SAShESample(A::DataFrame, B::DataFrame, permutations::Matrix{Int64})
+
+SAShE samples (`X`) and permutations (`π`).
+
+# Examples
+```julia
+import QuasiMonteCarlo as QMC
+using Distributions
+using Random
+
+function ishigami(X::Vector{Float64}; a::Float64=7.0, b::Float64=0.1)
+    return (1 + b * X[3]^4) * sin(X[1]) + a * (sin(X[2]))^2
+end
+
+# With pre-defined samples `A` and `B`
+du = Uniform(-π, π)
+n_samples = 1000
+n_factors = 3
+
+# Samples with shape [n_samples ⋅ n_factors] and known permutations
+A = DataFrame(rand(du, n_samples, n_factors), factor_names)
+B = DataFrame(rand(du, n_samples, n_factors), factor_names)
+permutations = ...
+
+S_x = SAShESample(A, B, permutations)
+Y = map(x -> ishigami(collect(x)), eachrow(S_x.samples))
+Φₙ, Φ²ₙ = analyze(S_x, Y)
+
+# With pre-defined samples (halved and split into `A` and `B`)
+X = Matrix(QMC.sample(2048, fill(-π, 3), fill(Float64(π), 3), Uniform())')
+S_x = SAShESample([:x1, :x2, :x3], X)
+Y = map(x -> ishigami(collect(x)), eachrow(S_x.samples))
+Φₙ, Φ²ₙ = analyze(S_x, Y)
+
+# With a given sampler to create custom permutations
+X = Matrix(QMC.sample(2048, fill(-π, 3), fill(Float64(π), 3), Uniform())')
+S_x = SAShESample([:x1, :x2, :x3], X, QMC.LatinHypercubeSample())
+Y = map(x -> ishigami(collect(x)), eachrow(S_x.samples))
+Φₙ, Φ²ₙ = analyze(S_x, Y)
+```
+
+$(FIELDS)
+"""
+struct SAShESample
+    "SAShE samples"
+    samples
+
+    "Permutation applied to generate samples."
+    permutations
+
+    function SAShESample(factor_names::Union{Vector{String},Vector{Symbol}}, n_samples::Int64, factor_dist::Vector)
+        X, p = create_sample(factor_names, n_samples, factor_dist)
+        return new(X, p)
+    end
+
+    function SAShESample(factor_names::Union{Vector{String},Vector{Symbol}}, samples::Matrix)
+        X, p = create_sample(factor_names, samples)
+        return new(X, p)
+    end
+
+    function SAShESample(factor_names::Union{Vector{String},Vector{Symbol}}, samples::Matrix, sampler)
+        A, B = _even_split(factor_names, samples)
+        X, p = _generate_samples(A, B, sampler)
+        return new(X, p)
+    end
+
+    function SAShESample(A::DataFrame, B::DataFrame, permutations::Matrix{Int64})
+        X, p = _generate_samples(A, B, permutations)
+        return new(X, p)
+    end
+end

--- a/src/shapley_effect.jl
+++ b/src/shapley_effect.jl
@@ -260,7 +260,7 @@ function analyze(X::DataFrame, Y::Vector, perms::Matrix)
 end
 
 """
-    analyze(S::SAShESample, Y)
+    analyze(S::SAShESample, Y::Vector)
 
 # Arguments
 - `S` : SAShE sample

--- a/src/shapley_effect.jl
+++ b/src/shapley_effect.jl
@@ -179,7 +179,6 @@ Tuple of matrices: Φₙ, Φ²ₙ, Yₙ
 - Φ²ₙ : Variance of Shapley effects used to estimate confidence bounds
 - Yₙ : Corresponding model result for base samples (size `N`)
 """
-
 function solve(problem::Problem)
     n_samples = problem.n_samples
 
@@ -198,6 +197,81 @@ function solve(problem::Problem)
 
     # TODO Return a better object, either a `Solution` or a new version of `Problem`
     return hcat([r[1] for r in res]...), hcat([r[2] for r in res]...), [r[3] for r in res]
+end
+
+"""
+    analyze(X::DataFrame, Y::Vector, perms::Matrix)
+
+# Arguments
+- `X` : Inputs used to run target model
+- `Y` : Resulting outputs from `X`
+- `perms` : Permutation order
+
+# Returns
+Tuple, of Φₙ and Φₙ² (Shapley Effect and variance)
+"""
+function analyze(X::DataFrame, Y::Vector, perms::Matrix)
+    n_var_params = size(X, 2)
+    n_base_samples = size(perms, 1)
+
+    check_size = Int64(size(X, 1) / (n_var_params + 1))
+    @assert check_size == n_base_samples "Sample sizes do not match!"
+
+    Φₙ_increments = zeros(n_base_samples, n_var_params)
+    Φₙ²_increments = zeros(n_base_samples, n_var_params)
+
+    Yₙ⁻ = zeros(n_var_params)
+    Yₙ⁺ = zeros(n_var_params)
+
+    for n in 1:n_base_samples
+        # For each sample...
+
+        # Calculate the starting index for this base sample
+        base_idx = (n - 1) * (n_var_params + 1) + 1
+
+        # Yₙ⁻ is the result for Xₙ, and gets replaced by Yₙ⁺
+        # Yₙ⁺ is the result for Xₙ₊₁
+        πₙ = perms[n, :]
+        Yₙ = Y[base_idx]
+
+        Yₙ⁻ .= 0.0
+        Yₙ⁺ .= 0.0
+        Yₙ⁻[πₙ[1]] = Yₙ  # Set first value according to permutation
+
+        for param_idx in 1:n_var_params
+            eval_idx = base_idx + param_idx
+            t_param_idx = πₙ[param_idx]
+
+            Yₙ⁺[t_param_idx] = Y[eval_idx]
+
+            f_diff = (Yₙ⁻[t_param_idx] - Yₙ⁺[t_param_idx])
+            f_arg = (Yₙ - Yₙ⁻[t_param_idx] / 2 - Yₙ⁺[t_param_idx] / 2) * f_diff
+
+            Φₙ_increments[n, t_param_idx] = f_arg * (1 / n_base_samples)
+            Φₙ²_increments[n, t_param_idx] = f_arg^2 * (1 / n_base_samples)
+
+            if param_idx < n_var_params
+                Yₙ⁻[πₙ[param_idx+1]] = Yₙ⁺[t_param_idx]
+            end
+        end
+    end
+
+    return (Matrix(Φₙ_increments'), Matrix(Φₙ²_increments'))
+end
+
+"""
+    analyze(S::SAShESample, Y)
+
+# Arguments
+- `S` : SAShE sample
+- `Y` : Model results
+
+# Returns
+Tuple, of Φₙ and Φₙ² (Shapley Effect and variance)
+"""
+function analyze(S::SAShESample, Y::Vector)
+    X = S.samples
+    return analyze(X, Y, S.permutations)
 end
 
 function Base.:show(io::IO, p::Problem)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,12 +4,12 @@ using DataFrames
 using Distributions
 using Random
 
+function ishigami(X::Vector{Float64}; a::Float64=7.0, b::Float64=0.1)
+    return (1 + b * X[3]^4) * sin(X[1]) + a * (sin(X[2]))^2
+end
+
 @testset "Ishigami function" begin
     Random.seed!(0987)
-
-    function ishigami(X::Vector{Float64}; a::Float64=7.0, b::Float64=0.1)
-        return (1 + b * X[3]^4) * sin(X[1]) + a * (sin(X[2]))^2
-    end
 
     factor_names = [:x1, :x2, :x3]
     n_samples, n_factors = 20000, 3
@@ -33,4 +33,35 @@ using Random
 
     @test all(abs.(((Φub .- Φlb) .- Φ_confint_base_vals)) .< (0.1 .* Φ_confint_base_vals))
     @test all(abs.(Φ .- Φ_base_vals) .< (0.1 .* Φ_base_vals))
+end
+
+@testset "Correctness of SAShESample assessment" begin
+    factor_names = [:x1, :x2, :x3]
+    n_samples = 1024
+    n_factors = length(factor_names)
+
+    du = Uniform(-π, π)
+
+    # Shape n_samples ⋅ n_factors
+    samples1 = DataFrame(rand(du, n_samples, n_factors), factor_names)
+    samples2 = DataFrame(rand(du, n_samples, n_factors), factor_names)
+
+    sa_problem = SAShE.Problem(ishigami, samples1, samples2)
+
+    Φₙ, Φ²ₙ, Yₙ = SAShE.solve(sa_problem)
+    Φ, Φlb, Φub = SAShE.shapley_effects(Φₙ, Φ²ₙ)
+
+    Φ_confint = SAShE.confint(Φₙ, Φ²ₙ)
+    Φ_moe = SAShE.margin_of_error(Φₙ, Φ²ₙ)
+
+    # Compare model variance with sum of Shapley Effects
+    @test min(var(Yₙ), sum(Φ)) / max(var(Yₙ), sum(Φ)) > 0.95 || "Ishigami did not converge"
+
+    S_x = SAShESample(samples1, samples2, sa_problem.permutations)
+    Y = map(x -> ishigami(collect(x)), eachrow(S_x.samples))
+    Φₙ, Φ²ₙ = SAShE.analyze(S_x, Y)
+    Φ2, Φlb2, Φub2 = SAShE.shapley_effects(Φₙ, Φ²ₙ)
+
+    # Ensure results are identical to initial analysis
+    @test all(Φ .== Φ2) || "Results do not match with same permutations"
 end


### PR DESCRIPTION
Adds functionality to generate and analyze samples using different sampling techniques.

Introduces a `SAShESample` struct to encapsulate samples and permutation data and implements `analyze` methods for Shapley effect analysis, including one that takes a `SAShESample` instance.

Adds `create_sample` and `_generate_samples` functions to support various sample generation scenarios.
I was originally going to simplify the method structures significantly - a lot of the `_generate_samples` could be moved into the SAShESample method constructors for example - but decided against it as they may be useful if lower-level tests are wanted/needed.

The `SAShESample` type also supports `QuasiMonteCarlo`-based samplers to allow sampling or permutation construction with different designs. This doesn't have a solid use case for now, but I suspect for high-dimensional problems, a more structured sampling design (such as Latin Hypercube) to create permutations may result in faster convergence. This needs further investigation.

In combination, these allow a user to generate samples $X$ to run with a model and assess its outputs ($Y$) and to do these activities independently of each other.

I also added a test case to compare against results from the original approach and ensure correctness of the analysis methods.